### PR TITLE
Respond to user's github issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,6 +242,18 @@
 
       .snippet-content {
         position: relative;
+        padding: 1rem 1.5rem;
+      }
+
+      .snippet-content pre {
+        margin: 0;
+        padding: 1rem;
+        line-height: 1.6;
+        white-space: pre-wrap;
+        word-break: break-word;
+        background: var(--card-background);
+        border: 1px solid var(--border-color);
+        border-radius: 0.5rem;
       }
 
       .copy-button {


### PR DESCRIPTION
Add CSS to `.snippet-content` and `pre` blocks to fix missing spacing and line breaks in new sections and code snippets.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7e6a9b4-d796-462b-b01d-18cf82f9282c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b7e6a9b4-d796-462b-b01d-18cf82f9282c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

